### PR TITLE
Inline style

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chai-webdriver": "^1.0.0",
     "fetch-mock": "^2.0.0",
     "mocha": "^2.1.0",
+    "next-build-tools": "^5.16.0",
     "origami-build-tools": "^4.2.0",
     "selenium-webdriver": "^2.46.1"
   },

--- a/scss/components/barriers/_inline.scss
+++ b/scss/components/barriers/_inline.scss
@@ -5,10 +5,10 @@
 /* inline class hacked into to app that results in barrier being invoked*/
 
 .inline {
-  .barrier-overlay,
-  .barrier-grid,
-  .premium-barrier-simple,
-  .subscription-barrier-grid,
+	.barrier-overlay,
+	.barrier-grid,
+	.premium-barrier-simple,
+	.subscription-barrier-grid,
 	.trial-barrier-grid{
 		z-index: auto;
 	}

--- a/scss/components/barriers/_is-inline.scss
+++ b/scss/components/barriers/_is-inline.scss
@@ -1,0 +1,15 @@
+/*********************************************
+* Styling for inline rendering of barriers
+**********************************************/
+
+/* inline class hacked into to app that results in barrier being invoked*/
+
+.inline {
+  .barrier-overlay,
+  .barrier-grid,
+  .premium-barrier-simple,
+  .subscription-barrier-grid,
+	.trial-barrier-grid{
+		z-index: auto;
+	}
+}

--- a/scss/components/barriers/_main.scss
+++ b/scss/components/barriers/_main.scss
@@ -15,3 +15,7 @@
 	left: 0;
 	z-index: 17;
 }
+
+.barrier__container {
+	@include oGridColspan(12 L10 center);
+}

--- a/scss/components/barriers/_main.scss
+++ b/scss/components/barriers/_main.scss
@@ -4,6 +4,8 @@
 @import 'barrier-grid';
 @import 'registration';
 @import 'suspended';
+@import 'inline';
+@import 'narrow';
 
 .barrier-overlay {
 	position: fixed;
@@ -14,8 +16,4 @@
 	top: 0;
 	left: 0;
 	z-index: 17;
-}
-
-.barrier__container {
-	@include oGridColspan(12 L10 center);
 }

--- a/scss/components/barriers/_narrow.scss
+++ b/scss/components/barriers/_narrow.scss
@@ -6,17 +6,38 @@
 
 
 .narrow {
-	.barrier-grid__option,
-	.subscription-barrier-grid__option,
+
+  &.barrier {
+    padding-right: 0;
+  }
+
+  .barrier-grid__option {
+    @include oGridColspan((default: full-width, M: one-half));
+    &.barrier-grid__option--option2 {
+      @include oGridRespondTo(M) {
+      	border-right: 0;
+      }
+    }
+  }
+	.subscription-barrier-grid__option {
+    @include oGridColspan((default: full-width, M: one-half));
+    &.subscription-barrier-grid__option--option2 {
+      @include oGridRespondTo(M) {
+        border-right: 0;
+      }
+    }
+  }
 	.trial-barrier-grid__option {
 		@include oGridColspan((default: full-width, M: one-half));
-	}
-
-	.barrier {
-		padding: 0;
+    &.trial-barrier-grid__option--option2 {
+      @include oGridRespondTo(M) {
+        border-right: 0;
+      }
+    }
 	}
 
 	.barrier__container {
-		@include oGridColspan(12)
+		@include oGridColspan(12);
+    padding-left: 0;
 	}
 }

--- a/scss/components/barriers/_narrow.scss
+++ b/scss/components/barriers/_narrow.scss
@@ -1,0 +1,22 @@
+/*********************************************
+* Styling for inline rendering of barriers
+**********************************************/
+
+/* narrow class hacked into to app that results in barrier being invoked*/
+
+
+.narrow {
+	.barrier-grid__option,
+	.subscription-barrier-grid__option,
+	.trial-barrier-grid__option {
+		@include oGridColspan((default: full-width, M: one-half));
+	}
+
+	.barrier {
+		padding: 0;
+	}
+
+	.barrier__container {
+		@include oGridColspan(12)
+	}
+}

--- a/scss/components/barriers/_subscription-grid.scss
+++ b/scss/components/barriers/_subscription-grid.scss
@@ -132,30 +132,27 @@
 		padding-top: 10px;
 		padding-bottom: 10px;
 		border-bottom: 1px solid oColorsGetPaletteColor('warm-2');
-		@include oGridRespondTo(S) {
-			min-height: 490px;
-		}
+		flex: 1;
 	}
-
-	.subscription-barrier-grid__option--option1 .subscription-barrier-grid__option-inner,
-	.subscription-barrier-grid__option--option3 .subscription-barrier-grid__option-inner {
-		@include oGridRespondTo(S) {
-			border-right: 1px solid oColorsGetPaletteColor('warm-2');
-		}
-	}
-
-	.subscription-barrier-grid__option--option1 .subscription-barrier-grid__option-inner,
-	.subscription-barrier-grid__option--option2 .subscription-barrier-grid__option-inner,
-	.subscription-barrier-grid__option--option3 .subscription-barrier-grid__option-inner {
-		@include oGridRespondTo(L) {
-			border-right: 1px solid oColorsGetPaletteColor('warm-2');
-		}
-	}
-
 
 	.subscription-barrier-grid__option {
 		@include oGridColumn((default: full-width, S: one-half, L: one-quarter));
 			@include oGridRemoveGutters();
+
+		&.subscription-barrier-grid__option--option1,
+		&.subscription-barrier-grid__option--option3 {
+			@include oGridRespondTo(S) {
+				border-right: 1px solid oColorsGetPaletteColor('warm-2');
+			}
+		}
+
+		&.subscription-barrier-grid__option--option1,
+		&.subscription-barrier-grid__option--option2,
+		&.subscription-barrier-grid__option--option3 {
+			@include oGridRespondTo(L) {
+				border-right: 1px solid oColorsGetPaletteColor('warm-2');
+			}
+		}
 	}
 
 	.subscription-barrier-grid__learn-more {

--- a/scss/components/barriers/_trial-grid.scss
+++ b/scss/components/barriers/_trial-grid.scss
@@ -156,31 +156,32 @@ $o-grid-gutters: (default: 0px, M: 0px);
 		background-color: oColorsGetPaletteColor('white');
 		padding-top: 20px;
 		padding-bottom: 10px;
-		border-bottom: 1px solid oColorsGetPaletteColor('warm-2');
-		@include oGridRespondTo(S) {
-			min-height: 560px;
-		}
-	}
 
-	.trial-barrier-grid__option--option1 .trial-barrier-grid__option-inner,
-	.trial-barrier-grid__option--option3 .trial-barrier-grid__option-inner {
-		@include oGridRespondTo(S) {
-			border-right: 1px solid oColorsGetPaletteColor('warm-2');
-		}
-	}
-
-	.trial-barrier-grid__option--option1 .trial-barrier-grid__option-inner,
-	.trial-barrier-grid__option--option2 .trial-barrier-grid__option-inner,
-	.trial-barrier-grid__option--option3 .trial-barrier-grid__option-inner {
-		@include oGridRespondTo(L) {
-			border-right: 1px solid oColorsGetPaletteColor('warm-2');
-		}
+		flex: 1;
 	}
 
 	.trial-barrier-grid__option {
+
 		@include oGridColspan((default: full-width, S: one-half, L: one-quarter));
 		background: white;
 		color: black;
+		border-bottom: 1px solid oColorsGetPaletteColor('warm-2');
+
+		&.trial-barrier-grid__option--option1,
+		&.trial-barrier-grid__option--option3 {
+			@include oGridRespondTo(S) {
+				border-right: 1px solid oColorsGetPaletteColor('warm-2');
+			}
+		}
+
+		&.trial-barrier-grid__option--option1,
+		&.trial-barrier-grid__option--option2,
+		&.trial-barrier-grid__option--option3 {
+			@include oGridRespondTo(L) {
+				border-right: 1px solid oColorsGetPaletteColor('warm-2');
+			}
+		}
+
 	}
 
 	.trial-barrier-grid__learn-more {
@@ -195,20 +196,21 @@ $o-grid-gutters: (default: 0px, M: 0px);
 }
 
 .trial-barrier-grid--missing-newspaper {
+
 	.trial-barrier-grid__option {
 		@include oGridColumn((default: full-width, M: one-third));
 		@include oGridRemoveGutters();
-	}
 
-	.trial-barrier-grid__option--option2 .trial-barrier-grid__option-inner,
-	.trial-barrier-grid__option--option3 .trial-barrier-grid__option-inner {
-		@include oGridRespondTo(M) {
-			border-right: 1px solid oColorsGetPaletteColor('warm-2');
+		&.trial-barrier-grid__option--option2,
+		&.trial-barrier-grid__option--option3 {
+			@include oGridRespondTo(M) {
+				border-right: 1px solid oColorsGetPaletteColor('warm-2');
+			}
 		}
-	}
 
-	.trial-barrier-grid__option--option4 .trial-barrier-grid__option-inner {
-		border-right: 0;
+		&.trial-barrier-grid__option--option4 {
+			border-right: 0;
+		}
 	}
 
 	.trial-barrier-grid__price {

--- a/scss/components/product-selector/main.scss
+++ b/scss/components/product-selector/main.scss
@@ -100,7 +100,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 			color: black;
 			text-decoration: none;
 			border-bottom-width: 0;
-		
+
 			&:hover {
 				text-decoration: none;
 			}
@@ -156,27 +156,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 		padding-top: 20px;
 		padding-bottom: 10px;
 		border-bottom: 1px solid oColorsGetPaletteColor('warm-2');
-		@include oGridRespondTo(S) {
-			min-height: 460px;
-		}
-		@include oGridRespondTo(M) {
-			min-height: 475px;
-		}
-	}
-
-	.product-selector__option--option1 .product-selector__option-inner,
-	.product-selector__option--option3 .product-selector__option-inner {
-		@include oGridRespondTo(S) {
-			border-right: 1px solid oColorsGetPaletteColor('warm-2');
-		}
-	}
-
-	.product-selector__option--option1 .product-selector__option-inner,
-	.product-selector__option--option2 .product-selector__option-inner,
-	.product-selector__option--option3 .product-selector__option-inner {
-		@include oGridRespondTo(L) {
-			border-right: 1px solid oColorsGetPaletteColor('warm-2');
-		}
+		flex: 1;
 	}
 
 	.product-selector__option {
@@ -184,7 +164,23 @@ $o-grid-gutters: (default: 0px, M: 0px);
 		@include oGridRespondTo(S) {
 			@include oGridRemoveGutters();
 		}
+
+		&.product-selector__option--option1,
+		&.product-selector__option--option3 {
+			@include oGridRespondTo(S) {
+				border-right: 1px solid oColorsGetPaletteColor('warm-2');
+			}
+		}
+
+		&.product-selector__option--option1,
+		&.product-selector__option--option2,
+		&.product-selector__option--option3 {
+			@include oGridRespondTo(L) {
+				border-right: 1px solid oColorsGetPaletteColor('warm-2');
+			}
+		}
 	}
+
 	.product-selector__learn-more {
 		@include oTypographySansBold(s);
 


### PR DESCRIPTION
Create styling for;

inline (i.e. not an overlay)
narrow (i.e. not full page width)

tidy up height of options to use flex that will make boxes in columns equal height and then put borders on the outside elements.

in conjunction with this PR to next-product-selector https://github.com/Financial-Times/next-product-selector/pull/46

Examples in FastFT open in stream

Desktop

![screen shot 2016-02-01 at 14 48 20](https://cloud.githubusercontent.com/assets/8938227/12720991/5c0d4952-c8f5-11e5-82d5-0644f687650e.png)

Mobile

![screen shot 2016-02-01 at 14 48 44](https://cloud.githubusercontent.com/assets/8938227/12720996/663c2498-c8f5-11e5-9df7-d2f135b7b3dd.png)

