### PR TITLE
Remove/replace old o-grid mixins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,5 +21,8 @@
     "next-sass-setup": "^7.0.5",
     "o-grid": "^4.0.5",
     "next-buttons": "~2.2.4"
+  },
+  "resolutions": {
+    "o-ft-icons": "next"
   }
 }

--- a/scss/components/barriers/_barrier-grid.scss
+++ b/scss/components/barriers/_barrier-grid.scss
@@ -237,7 +237,6 @@
 
 	.barrier-grid__option {
 		@include oGridColumn((default: full-width, S: one-half, L: one-quarter));
-		@include oGridRemoveGutters();
 		border-bottom: 1px solid oColorsGetPaletteColor('warm-2');
 		padding-bottom: 20px;
 	}
@@ -251,7 +250,6 @@
 .barrier-grid--missing-newspaper {
 	.barrier-grid__option {
 		@include oGridColumn((default: full-width, M: one-third));
-		@include oGridRemoveGutters();
 	}
 
 	.barrier-grid__option--option2 .barrier-grid__option-inner,

--- a/scss/components/barriers/_barrier-grid.scss
+++ b/scss/components/barriers/_barrier-grid.scss
@@ -13,7 +13,7 @@
 	background-color: oColorsGetPaletteColor('warm-2');
 	h2 {
 		@include oTypographySansBold(m);
-		@include oGridColumn((default: full-width, L: three-quarters));
+		@include oGridColspan((default: full-width, L: three-quarters));
 	}
 
 	h2 {
@@ -33,7 +33,7 @@
 
 	.barrier-grid__sign-in {
 		@include oTypographySansBold(s);
-		@include oGridColumn((default: full-width, L: one-quarter));
+		@include oGridColspan((default: full-width, L: one-quarter));
 
 		background-color: oColorsGetPaletteColor('warm-3');
 		padding: 10px 25px;
@@ -236,7 +236,7 @@
 
 
 	.barrier-grid__option {
-		@include oGridColumn((default: full-width, S: one-half, L: one-quarter));
+		@include oGridColspan((default: full-width, S: one-half, L: one-quarter));
 		border-bottom: 1px solid oColorsGetPaletteColor('warm-2');
 		padding-bottom: 20px;
 	}
@@ -249,7 +249,7 @@
 
 .barrier-grid--missing-newspaper {
 	.barrier-grid__option {
-		@include oGridColumn((default: full-width, M: one-third));
+		@include oGridColspan((default: full-width, M: one-third));
 	}
 
 	.barrier-grid__option--option2 .barrier-grid__option-inner,

--- a/scss/components/barriers/_premium.scss
+++ b/scss/components/barriers/_premium.scss
@@ -28,7 +28,7 @@
 
 	h2 {
 		@include oTypographySansBold(m);
-		@include oGridColumn((default: full-width, L: three-quarters));
+		@include oGridColspan((default: full-width, L: three-quarters));
 		margin: 0;
 	}
 
@@ -49,7 +49,7 @@
 
 	.premium-barrier-simple__sign-in {
 		@include oTypographySansBold(s);
-		@include oGridColumn((default: full-width, L: one-quarter));
+		@include oGridColspan((default: full-width, L: one-quarter));
 
 		background-color: oColorsGetPaletteColor('warm-3');
 		padding: 10px;
@@ -106,7 +106,7 @@
 }
 
 .premium-barrier-simple__other-option {
-	@include oGridColumn((default: one-half, L: 3));
+	@include oGridColspan((default: one-half, L: 3));
 
 	.premium-barrier-simple__other-option-inner {
 		text-align: center;

--- a/scss/components/barriers/_subscription-grid.scss
+++ b/scss/components/barriers/_subscription-grid.scss
@@ -136,7 +136,6 @@
 
 	.subscription-barrier-grid__option {
 		@include oGridColumn((default: full-width, S: one-half, L: one-quarter));
-			@include oGridRemoveGutters();
 
 		&.subscription-barrier-grid__option--option1,
 		&.subscription-barrier-grid__option--option3 {

--- a/scss/components/barriers/_subscription-grid.scss
+++ b/scss/components/barriers/_subscription-grid.scss
@@ -13,7 +13,7 @@
 	background-color: oColorsGetPaletteColor('warm-2');
 	h2 {
 		@include oTypographySansBold(m);
-		@include oGridColumn((default: full-width, L: three-quarters));
+		@include oGridColspan((default: full-width, L: three-quarters));
 	}
 
 	h2 {
@@ -135,7 +135,7 @@
 	}
 
 	.subscription-barrier-grid__option {
-		@include oGridColumn((default: full-width, S: one-half, L: one-quarter));
+		@include oGridColspan((default: full-width, S: one-half, L: one-quarter));
 
 		&.subscription-barrier-grid__option--option1,
 		&.subscription-barrier-grid__option--option3 {
@@ -177,7 +177,7 @@
 }
 
 .subscription-barrier-grid__other-option {
-	@include oGridColumn((default: one-third));
+	@include oGridColspan((default: one-third));
 
 	.subscription-barrier-grid__other-option-inner {
 		text-align: center;

--- a/scss/components/barriers/_trial-grid.scss
+++ b/scss/components/barriers/_trial-grid.scss
@@ -15,7 +15,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 	background-color: oColorsGetPaletteColor('warm-2');
 	h2 {
 		@include oTypographySansBold(m);
-		@include oGridColumn((default: full-width, L: three-quarters));
+		@include oGridColspan((default: full-width, L: three-quarters));
 	}
 
 	h2 {
@@ -35,7 +35,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 
 	.trial-barrier-grid__sign-in {
 		@include oTypographySansBold(s);
-		@include oGridColumn((default: full-width, L: one-quarter));
+		@include oGridColspan((default: full-width, L: one-quarter));
 
 		background-color: oColorsGetPaletteColor('warm-3');
 		padding: 10px;
@@ -197,7 +197,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 .trial-barrier-grid--missing-newspaper {
 
 	.trial-barrier-grid__option {
-		@include oGridColumn((default: full-width, M: one-third));
+		@include oGridColspan((default: full-width, M: one-third));
 
 		&.trial-barrier-grid__option--option2,
 		&.trial-barrier-grid__option--option3 {
@@ -238,7 +238,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 }
 
 .trial-barrier-grid__other-option {
-	@include oGridColumn((default: one-third));
+	@include oGridColspan((default: one-third));
 
 	.trial-barrier-grid__other-option-inner {
 		text-align: center;

--- a/scss/components/barriers/_trial-grid.scss
+++ b/scss/components/barriers/_trial-grid.scss
@@ -198,7 +198,6 @@ $o-grid-gutters: (default: 0px, M: 0px);
 
 	.trial-barrier-grid__option {
 		@include oGridColumn((default: full-width, M: one-third));
-		@include oGridRemoveGutters();
 
 		&.trial-barrier-grid__option--option2,
 		&.trial-barrier-grid__option--option3 {

--- a/scss/components/product-selector/main.scss
+++ b/scss/components/product-selector/main.scss
@@ -161,9 +161,6 @@ $o-grid-gutters: (default: 0px, M: 0px);
 
 	.product-selector__option {
 		@include oGridColumn((default: full-width, S: one-half, L: one-quarter));
-		@include oGridRespondTo(S) {
-			@include oGridRemoveGutters();
-		}
 
 		&.product-selector__option--option1,
 		&.product-selector__option--option3 {
@@ -226,7 +223,6 @@ $o-grid-gutters: (default: 0px, M: 0px);
 
 .product-selector__other-option {
 	@include oGridColumn((default: full-width, S: one-third));
-	@include oGridRemoveGutters();
 
 	.product-selector__other-option-inner {
 		text-align: center;

--- a/scss/components/product-selector/main.scss
+++ b/scss/components/product-selector/main.scss
@@ -17,7 +17,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 	padding: 10px;
 	h1 {
 		@include oTypographySansBold(m);
-		@include oGridColumn((default: full-width, L: three-quarters));
+		@include oGridColspan((default: full-width, L: three-quarters));
 		text-align: center;
 		margin-bottom: 10px;
 		padding-left: 10px;
@@ -30,7 +30,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 
 	.product-selector__sign-in {
 		@include oTypographySansBold(s);
-		@include oGridColumn((default: full-width, L: one-quarter));
+		@include oGridColspan((default: full-width, L: one-quarter));
 		text-align: center;
 		padding-right: 10px;
 
@@ -160,7 +160,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 	}
 
 	.product-selector__option {
-		@include oGridColumn((default: full-width, S: one-half, L: one-quarter));
+		@include oGridColspan((default: full-width, S: one-half, L: one-quarter));
 
 		&.product-selector__option--option1,
 		&.product-selector__option--option3 {
@@ -222,7 +222,7 @@ $o-grid-gutters: (default: 0px, M: 0px);
 }
 
 .product-selector__other-option {
-	@include oGridColumn((default: full-width, S: one-third));
+	@include oGridColspan((default: full-width, S: one-third));
 
 	.product-selector__other-option-inner {
 		text-align: center;


### PR DESCRIPTION
Removes `oGridRemoveGutters` (it doesn't do anything anymore)
Renames `oGridColumn` to `oGridColspan`, which for the past few months has actually been [the same underneath](https://github.com/Financial-Times/next-sass-setup/blob/master/main.scss#L61).

Let's get rid of those console warnings!