### PR TITLE
Don't use element selector for corporate-special heading

### DIFF
--- a/scss/components/barriers/_corporate-special.scss
+++ b/scss/components/barriers/_corporate-special.scss
@@ -1,6 +1,6 @@
 .corporate-special {
 
-	h2 {
+	.corporate-special__heading {
 		padding: 10px 10px;
 		@include oGridRespondTo(L) {
 			line-height: 50px;	


### PR DESCRIPTION
As was causing issues when used with other barriers.