### PR TITLE
use new image service

### DIFF
--- a/scss/components/barriers/_corporate-prominence.scss
+++ b/scss/components/barriers/_corporate-prominence.scss
@@ -3,11 +3,11 @@
 	.trial-barrier-grid__header--redesign {
 		margin-bottom: 20px;
 		letter-spacing: 0.2px;
-	
+
 		.trial-barrier-grid__pretext--redesign {
 			padding-left: 10px;
 			@include oGridRespondTo(L) {
-				display: inline-block;	
+				display: inline-block;
 			}
 		}
 
@@ -34,7 +34,7 @@
 			font-size: 17px;
 			padding: 0px;
 			margin-bottom:10px;
-			
+
 			.barrier-grid__article-title--redesign {
 				display: inline-block;
 				padding-left: 10px;
@@ -62,7 +62,7 @@
 		@include oGridRespondTo(L) {
 			display:flex;
 			min-width: 100%;
-		}	
+		}
 	}
 
 
@@ -129,7 +129,7 @@
 		display: block;
 		position: absolute;
 		margin-top: -9px;
-		background: url(https://next-geebee.ft.com/image/v1/images/raw/http%3a%2f%2fnext-geebee.ft.com%2fassets%2fbackgrounds%2ffront-page-section-header-v2.svg?source=next&format=svg&tint=000000,000000) repeat transparent;
+		background: url(https://www.ft.com/__origami/service/image/v2/images/raw/http%3a%2f%2fnext-geebee.ft.com%2fassets%2fbackgrounds%2ffront-page-section-header-v2.svg?source=next&format=svg&tint=000000,000000) repeat transparent;
 	}
 
 	.section-meta {
@@ -145,7 +145,7 @@
 			position:relative;
 		}
 	}
-	
+
 	.section-meta--team {
 		border-bottom:5px solid oColorsGetPaletteColor('pink');
 	}
@@ -242,12 +242,12 @@
 			h3 {
 				margin-bottom: 7px;
 				height:36px;
-				
+
 				a {
 					border-bottom: none;
 					font-size: 18px;
 					letter-spacing: 0.2px;
-				}	
+				}
 			}
 
 			.trial-barrier-grid__image--redesign {
@@ -265,24 +265,24 @@
 				margin-top: -10px;
 				margin-bottom: 30px;
 				color: oColorsGetPaletteColor('cold-1');;
-			
+
 				.trial-barrier-grid__price--redesign,
 			        .trial-barrier-grid__price--redesignstandout {
 					font-size: 17px;
 					display: block;
 					margin-bottom: 15px;
 					letter-spacing: 0.2px;
-				
+
 					.trial-barrier-grid__price-link {
 						border: none;
 						border-bottom: 1px solid oColorsGetPaletteColor('teal-1');
 					}
 				}
-				
+
 				.trial-barrier-grid__select--redesign {
 					background-color: white;
 					color: oColorsGetPaletteColor('teal-1');
-				}	
+				}
 			}
 
 			.trial-barrier-grid__channel {
@@ -295,7 +295,7 @@
 				padding-left: 25px;
 				padding-right:25px;
 				color: oColorsGetPaletteColor('cold-1');;
-			
+
 				li, h4 {
 					margin-top:10px;
 				}
@@ -377,21 +377,21 @@
 			padding-top:25px;
 			h3 {
 				margin-bottom: 7px;
-				height:40px;	
+				height:40px;
 				a {
 					border-bottom: none;
 					font-size: 18px;
 					letter-spacing: 0.2px;
-				}	
+				}
 			}
 		}
 
 		.trial-barrier-grid__other-option-select--redesign {
 			background-color: white;
 			color:  oColorsGetPaletteColor('teal-1');;
-		}	
+		}
 	}
-	
+
 	.trial-barrier-grid__terms {
 		margin-top:15px;
 		color: oColorsGetPaletteColor('cold-1');


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2